### PR TITLE
Use 24h format for hours in the timestamp example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ A migration looks like the following:
 
 Each important part of the migration is numbered:
 
-1. Every migration has to be decorated with the **MigrationAttribute**, and needs to be seeded it with a **long* value. We recommend you seed it with a **DateTime** stamp of yyyyMMddhhmmss ex. 20131031083545. This helps keeps teams for guessing and conflicting on the next migration number.
+1. Every migration has to be decorated with the **MigrationAttribute**, and needs to be seeded it with a **long* value. We recommend you seed it with a **DateTime** stamp of yyyyMMddHHmmss ex. 20131031083545. This helps keeps teams for guessing and conflicting on the next migration number.
 2. Every migration needs to implement from the base class of **Migration**. This gives you access to base functionality and the ability to implement **Up** and **Down**.
 3. **Up** is the method that occurs when a migration is executed. As you see above, we are adding a document.
 4. **Down** is the method that occurs when a migration is rolledback. This is not always possible, but if it is, then it most likely will be the reverse of **Up**.


### PR DESCRIPTION
This probably wouldn't matter much, but using 12h format would mean that a migration done at 10am would come after a migration done at 2pm
