### PR TITLE
Modify Alter.Collection to use Streaming API so it doesn't miss documents if the index changes

### DIFF
--- a/RavenMigrations.Tests/RunnerTests.cs
+++ b/RavenMigrations.Tests/RunnerTests.cs
@@ -254,6 +254,7 @@ namespace RavenMigrations.Tests
 
         public override void Down()
         {
+            WaitForIndexing();
             DocumentStore.DatabaseCommands.DeleteByIndex(new TestDocumentIndex().IndexName, new IndexQuery());
         }
     }

--- a/RavenMigrations/Runner.cs
+++ b/RavenMigrations/Runner.cs
@@ -92,8 +92,9 @@ namespace RavenMigrations
 
         private static bool IsInCurrentMigrationProfile(MigrationWithAttribute migrationWithAttribute, MigrationOptions options)
         {
-            return string.IsNullOrWhiteSpace(migrationWithAttribute.Attribute.Profile) ||
-            options.Profiles.Any(x => StringComparer.InvariantCultureIgnoreCase.Compare(migrationWithAttribute.Attribute.Profile, x) == 0);
+            return migrationWithAttribute.Attribute != null &&
+                   (string.IsNullOrWhiteSpace(migrationWithAttribute.Attribute.Profile) ||
+                    options.Profiles.Any(x => StringComparer.InvariantCultureIgnoreCase.Compare(migrationWithAttribute.Attribute.Profile, x) == 0));
         }
     }
 }


### PR DESCRIPTION
We had a problem where we were deleting and adding documents during an Alter.Collection, and RavenMigrations was successfully migrating the first pageSize of documents but then not migrating any more. This was because the index was getting changed and therefore the paging methodology used was producing changing results, because each paged query to the index is looking at a different version of the index.

I've rewritten it to use [RavenDB's Streaming API][1] which is what we should be using if we want to stably enumerate though all documents in the database. The Streaming API will take a snapshot of the index at the time of the query and use that, so we are free to add/remove documents at will without affecting the enumeration. It's also streaming, so we aren't loading the whole DB into memory.

I've also fixed a few bugs that were causing the integration tests to fail.

Let me know if I've missed anything or made any mistakes! :)

[1]: http://ayende.com/blog/161249/ravendbs-querying-streaming-unbounded-results