### PR TITLE
Allow the ability to migrate a subset of documents in a collection efficiently

### DIFF
--- a/RavenMigrations.Tests/AlterTests.cs
+++ b/RavenMigrations.Tests/AlterTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
 using FluentAssertions;
 using Raven.Abstractions.Data;
 using Raven.Client;
@@ -59,6 +61,36 @@ namespace RavenMigrations.Tests
             }
         }
 
+        [Fact]
+        public void Can_migrate_only_subset()
+        {
+            using (var store = NewDocumentStore())
+            {
+                var lastModifieds = InitialiseWithAnimals(store);
+
+                Thread.Sleep(50);
+
+                var migration = new AlterCollectionSubsetMigration();
+                migration.Setup(store);
+
+                migration.Up();
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var animal1 = session.Load<Animal>("Animals/1");
+                    animal1.Name.Should().Be("Lion");
+                    var animal2 = session.Load<Animal>("Animals/2");
+                    animal2.Name.Should().Be("Tiger");
+
+                    var metadata1 = session.Advanced.GetMetadataFor(animal1);
+                    metadata1[Constants.LastModified].Value<DateTime>().Should().NotBe(lastModifieds[0]);
+                    var metadata2 = session.Advanced.GetMetadataFor(animal2);
+                    metadata2[Constants.LastModified].Value<DateTime>().Should().Be(lastModifieds[1]);
+                }
+            }
+        }
+
         private void InitialiseWithPerson(IDocumentStore store, string name)
         {
             new RavenDocumentsByEntityName().Execute(store); //https://groups.google.com/forum/#!topic/ravendb/QqZPrRUwEkE
@@ -68,6 +100,31 @@ namespace RavenMigrations.Tests
                 session.SaveChanges();
             }
             WaitForIndexing(store);
+        }
+
+        private List<DateTime> InitialiseWithAnimals(IDocumentStore store)
+        {
+            var lastModifieds = new List<DateTime>();
+            new RavenDocumentsByEntityName().Execute(store); //https://groups.google.com/forum/#!topic/ravendb/QqZPrRUwEkE
+            using (var session = store.OpenSession())
+            {
+                var animal1 = new Animal { Id = "Animals/1", Name = "Lyon" };
+                var animal2 = new Animal { Id = "Animals/2", Name = "Tiger" };
+                
+                session.Store(animal1);
+                session.Store(animal2);
+
+                session.SaveChanges();
+
+                var metadata1 = session.Advanced.GetMetadataFor(animal1);
+                var metadata2 = session.Advanced.GetMetadataFor(animal2);
+
+                lastModifieds.Add(metadata1[Constants.LastModified].Value<DateTime>());
+                lastModifieds.Add(metadata2[Constants.LastModified].Value<DateTime>());
+            }
+            WaitForIndexing(store);
+
+            return lastModifieds;
         }
     }
 
@@ -109,6 +166,25 @@ namespace RavenMigrations.Tests
         }
     }
 
+    public class AlterCollectionSubsetMigration : Migration
+    {
+        public override void Up()
+        {
+            Alter.CollectionSubset("Animals", MigrateDocument);
+        }
+
+        private bool MigrateDocument(RavenJObject doc, RavenJObject metadata)
+        {
+            if (doc["Name"].Value<string>() == "Lyon")
+            {
+                doc["Name"] = new RavenJValue("Lion");
+                return true;
+            }
+
+            return false;
+        }
+    }
+
     public class Person1
     {
         public string Id { get; set; }
@@ -120,5 +196,11 @@ namespace RavenMigrations.Tests
         public string FirstName { get; set; }
         public string Id { get; set; }
         public string LastName { get; set; }
+    }
+
+    public class Animal
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
     }
 }

--- a/RavenMigrations.Tests/RavenMigrations.Tests.csproj
+++ b/RavenMigrations.Tests/RavenMigrations.Tests.csproj
@@ -99,6 +99,9 @@
       <Name>RavenMigrations</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/RavenMigrations.Tests/RunnerTests.cs
+++ b/RavenMigrations.Tests/RunnerTests.cs
@@ -254,6 +254,7 @@ namespace RavenMigrations.Tests
 
         public override void Down()
         {
+            WaitForIndexing();
             DocumentStore.DatabaseCommands.DeleteByIndex(new TestDocumentIndex().IndexName, new IndexQuery());
         }
     }

--- a/RavenMigrations/Properties/AssemblyInfo.cs
+++ b/RavenMigrations/Properties/AssemblyInfo.cs
@@ -34,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.1.0")]
 [assembly: AssemblyFileVersion("1.0.1.0")]
+
+[assembly:InternalsVisibleTo("RavenMigrations.Tests")]

--- a/RavenMigrations/Runner.cs
+++ b/RavenMigrations/Runner.cs
@@ -92,8 +92,9 @@ namespace RavenMigrations
 
         private static bool IsInCurrentMigrationProfile(MigrationWithAttribute migrationWithAttribute, MigrationOptions options)
         {
-            return string.IsNullOrWhiteSpace(migrationWithAttribute.Attribute.Profile) ||
-            options.Profiles.Any(x => StringComparer.InvariantCultureIgnoreCase.Compare(migrationWithAttribute.Attribute.Profile, x) == 0);
+            return migrationWithAttribute.Attribute != null &&
+                   (string.IsNullOrWhiteSpace(migrationWithAttribute.Attribute.Profile) ||
+                    options.Profiles.Any(x => StringComparer.InvariantCultureIgnoreCase.Compare(migrationWithAttribute.Attribute.Profile, x) == 0));
         }
     }
 }

--- a/RavenMigrations/Verbs/Alter.cs
+++ b/RavenMigrations/Verbs/Alter.cs
@@ -2,8 +2,11 @@
 using System.Collections.Generic;
 using Raven.Abstractions.Commands;
 using Raven.Abstractions.Data;
+using Raven.Abstractions.Indexing;
 using Raven.Client;
+using Raven.Client.Indexes;
 using Raven.Json.Linq;
+using RavenMigrations.Extensions;
 
 namespace RavenMigrations.Verbs
 {
@@ -14,6 +17,40 @@ namespace RavenMigrations.Verbs
         public Alter(IDocumentStore documentStore)
         {
             DocumentStore = documentStore;
+        }
+
+        /// <summary>
+        /// Allows migration of documents that are returned by a query to an index you can temporarily
+        /// create in order to find documents quickly.
+        /// </summary>
+        /// <param name="map">The Map part of the index (see <see cref="IndexDefinition.Map"/>)</param>
+        /// <param name="query">The lucene query text to query the index with</param>
+        /// <param name="documentMigrator">
+        /// The function to migrate a single document and metadata. 
+        /// Returns true if the document has been modified and should be saved, false otherwise
+        /// </param>
+        /// <param name="pageSize">The page size for batching the documents.</param>
+        public void DocumentsViaTempIndex(string map, string query, DocumentMigrator documentMigrator, int pageSize = 128)
+        {
+            DocumentStore.ExecuteIndex(new TemporaryMigrationIndex(map));
+            DocumentStore.WaitForIndexing();
+
+            try
+            {
+                QueryHeaderInformation headerInfo;
+                var enumerator = DocumentStore.DatabaseCommands.StreamQuery(TemporaryMigrationIndex.Name,
+                    new IndexQuery
+                    {
+                        Query = query,
+                    },
+                    out headerInfo);
+
+                MigrateDocumentsFromEnumerator(enumerator, documentMigrator, pageSize);
+            }
+            finally
+            {
+                DocumentStore.DatabaseCommands.DeleteIndex(TemporaryMigrationIndex.Name);
+            }
         }
 
         /// <summary>
@@ -37,6 +74,11 @@ namespace RavenMigrations.Verbs
                 out headerInfo);
 
 
+            MigrateDocumentsFromEnumerator(enumerator, documentMigrator, pageSize);
+        }
+
+        private void MigrateDocumentsFromEnumerator(IEnumerator<RavenJObject> enumerator, DocumentMigrator documentMigrator, int pageSize)
+        {
             var cmds = new List<ICommandData>();
             using (enumerator)
             while (enumerator.MoveNext())
@@ -81,5 +123,25 @@ namespace RavenMigrations.Verbs
         }
 
         protected IDocumentStore DocumentStore { get; private set; }
+
+        internal class TemporaryMigrationIndex : AbstractIndexCreationTask
+        {
+            public const string Name = "TemporaryMigrationIndex";
+            private readonly string _map;
+
+            public TemporaryMigrationIndex(string map)
+            {
+                _map = map;
+            }
+
+            public override IndexDefinition CreateIndexDefinition()
+            {
+                return new IndexDefinition
+                {
+                    Name = Name,
+                    Map = _map
+                };
+            }
+        }
     }
 }


### PR DESCRIPTION
We needed to be able to migrate a subset of documents efficiently. The current Alter.Collection will: 
- always update each document regardless of whether it has changed
- always load every document in the collection

I've created a new Alter.CollectionSubset method that is similar to Alter.Collection, but it takes a function that also returns a bool to indicate whether or not the document should be saved back to the database. That way, if the document doesn't need migration, it can be skipped.

In the case where you know there's a small subset of documents that need migration, it is inefficient to enumerate through all documents in the collection. I've created a new Alter.DocumentsViaTempIndex method that allows you to specify a Map index definition, a lucene query string to query it with, and a migrator callback function like Alter.CollectionSubset. The method automatically creates an index, waits for it to not be stale, performs your migration based on the returned documents, then deletes the index when you're done.

This pull request is based on top of changes in pull request #17, so that'd need to be merged first before merging this one.
