### PR TITLE
Increment the version in one place.

### DIFF
--- a/RavenMigrations/Properties/AssemblyInfo.cs
+++ b/RavenMigrations/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -10,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("RavenMigrations")]
-[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyCopyright("Copyright © 2013")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -22,15 +21,8 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("75a19d4a-7e62-46d2-ae57-7427a16b1105")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+// AppVeyor's build process will patch this with the correct assembly version.
+// If you need to bump the version, do it in the appveyor.yml
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]
+[assembly: AssemblyInformationalVersion("0.0.0.0")]

--- a/RavenMigrations/RavenMigrations.nuspec
+++ b/RavenMigrations/RavenMigrations.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>RavenMigrations</id>
-        <version>1.0.1</version>
+        <version>$version$</version>
         <title>Raven Migrations</title>
         <authors>Khalid Abuhakmeh</authors>
         <owners>khalidabuhakmeh</owners>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+version: $(core_version)+{branch}.{build}
+configuration: Release
+assembly_info:
+  patch: true
+  file: '**\AssemblyInfo.*'
+  assembly_version: $(core_version)
+  assembly_file_version: $(core_version)
+  assembly_informational_version: $(core_version)
+environment:
+  core_version: 1.0.1
+nuget:
+  project_feed: true
+  disable_publish_on_pr: true
+build:
+  publish_nuget: true
+  publish_nuget_symbols: true
+  include_nuget_references: true
+  verbosity: minimal

--- a/readme.md
+++ b/readme.md
@@ -243,3 +243,7 @@ Thanks goes to [Sean Kearon](https://github.com/seankearon) who helped dog food 
 ## Versioning
 
 This project strives to adhere to the [semver](http://semver.org) guidelines.
+
+The version for this project should be controlled by the settings in the appveyor.yml file. There is an environment variable that sets the core version,
+which is usually the only place the version would need to be changed. For prerelease or other version formats based on the semver guidelines, the
+assembly_informational_version would need to be changed because assembly_version does not support these semver formats.


### PR DESCRIPTION
Support incrementing the version in one place by allowing the nuspec to
pick up the version from the assembly info, and letting AppVeyor patch
the assembly info as part of the build process.

Add appveyor.yml to the project root. SemVer style version changes
should be made the the core_version property in the appveyor.yml.