### PR TITLE
Allow migrations to produce additional commands

### DIFF
--- a/RavenMigrations/Verbs/Alter.cs
+++ b/RavenMigrations/Verbs/Alter.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Raven.Abstractions.Commands;
 using Raven.Abstractions.Data;
+using Raven.Abstractions.Extensions;
 using Raven.Client;
 using Raven.Json.Linq;
 
@@ -20,7 +22,7 @@ namespace RavenMigrations.Verbs
         /// <param name="tag">The name of the collection.</param>
         /// <param name="action">The action to migrate a single document and metadata.</param>
         /// <param name="pageSize">The page size for batching the documents.</param>
-        public void Collection(string tag, Action<RavenJObject, RavenJObject> action, int pageSize = 128)
+        public void Collection(string tag, Func<RavenJObject, RavenJObject, IEnumerable<ICommandData>> action, int pageSize = 128)
         {
             QueryHeaderInformation headerInfo;
             var enumerator = DocumentStore.DatabaseCommands.StreamQuery("Raven/DocumentsByEntityName",
@@ -31,33 +33,61 @@ namespace RavenMigrations.Verbs
                 out headerInfo);
 
 
-            var cmds = new List<ICommandData>();
+            var actions = new RavenActions();
             using (enumerator)
             while (enumerator.MoveNext())
             {
                 var entity = enumerator.Current;
                 var metadata = entity.Value<RavenJObject>("@metadata");
 
-                action(entity, metadata);
+                var actionCommands = action(entity, metadata);
 
-                cmds.Add(new PutCommandData
+                if (actionCommands != null && actionCommands.ToList().Any())
+                {
+                    actions.AdditionalMigrationCommands.AddRange(actionCommands);
+                }
+
+                actions.MigrationCommands.Add(new PutCommandData
                 {
                     Document = entity,
                     Metadata = metadata,
                     Key = metadata.Value<string>("@id"),
                 });
 
-                if (cmds.Count == pageSize)
+                if (actions.MigrationCommands.Count == pageSize)
                 {
-                    DocumentStore.DatabaseCommands.Batch(cmds.ToArray());
-                    cmds.Clear();
+                    DocumentStore.DatabaseCommands.Batch(actions.AllCommands());
+                    actions.ClearMigrationCommands();
                 }
             }
 
-            if (cmds.Count > 0)
-                DocumentStore.DatabaseCommands.Batch(cmds.ToArray());
+            if (actions.AllCommands().Count > 0)
+                DocumentStore.DatabaseCommands.Batch(actions.AllCommands());
         }
 
         protected IDocumentStore DocumentStore { get; private set; }
+    }
+
+    public class RavenActions
+    {
+        public IList<ICommandData> MigrationCommands { get; set; }
+        public IList<ICommandData> AdditionalMigrationCommands { get; set; }
+
+        public RavenActions()
+        {
+            MigrationCommands = new List<ICommandData>();
+            AdditionalMigrationCommands = new List<ICommandData>();
+        }
+
+        public IList<ICommandData> AllCommands()
+        {
+            return MigrationCommands.Union(AdditionalMigrationCommands).ToList();
+        }
+
+        public void ClearMigrationCommands()
+        {
+            MigrationCommands.Clear();
+            AdditionalMigrationCommands.Clear();
+        }
     }
 }


### PR DESCRIPTION
Alter.Collection can be used now to add additional ICommandData to the
Alter.Collection batch. This makes it so you can safely add new
documents or make changes to additional documents and have it be part of
the same batch / transaction.

This changes the API of Alter.Collection though, so this might need to
be changed to allow for both the Action and the Func.