### PR TITLE
Added additional filter when finding all migration classes: now requi…

### DIFF
--- a/RavenMigrations/Runner.cs
+++ b/RavenMigrations/Runner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Raven.Client;
+using Raven.Client.Indexes;
 
 namespace RavenMigrations
 {
@@ -68,11 +69,12 @@ namespace RavenMigrations
             {
                 var migrationsFromAssembly =
                     from t in assembly.GetLoadableTypes()
-                    where typeof(Migration).IsAssignableFrom(t)
+                    let attr = t.GetMigrationAttribute()
+                    where typeof(Migration).IsAssignableFrom(t) && attr != null
                     select new MigrationWithAttribute
                     {
                         Migration = () => options.MigrationResolver.Resolve(t),
-                        Attribute = t.GetMigrationAttribute()
+                        Attribute = attr
                     };
 
                 migrations.AddRange(migrationsFromAssembly);


### PR DESCRIPTION
Added additional filter when finding all migration classes: now requires both the migration class to inherit from Migration, and to be decorated with MigrationAttribute

This fixes Issue #18 - and separates out the fix from existing pull request 19 (multiple underscores).