### PR TITLE
New option to use alternative migration to MigrationDocument id conversion

### DIFF
--- a/RavenMigrations.Tests/RunnerTests.cs
+++ b/RavenMigrations.Tests/RunnerTests.cs
@@ -205,11 +205,11 @@ namespace RavenMigrations.Tests
                         .Should().Be(1);
 
                     var secondMigrationDocument =
-                        session.Load<MigrationDocument>(new Second_Migration().GetMigrationIdFromName());
+                        session.Load<MigrationDocument>(RavenMigrationHelpers.GetMigrationIdFromName(new Second_Migration()));
                     secondMigrationDocument.Should().BeNull();
 
                     var firstMigrationDocument =
-                        session.Load<MigrationDocument>(new First_Migration().GetMigrationIdFromName());
+                        session.Load<MigrationDocument>(RavenMigrationHelpers.GetMigrationIdFromName(new First_Migration()));
                     firstMigrationDocument.Should().NotBeNull();
                 }
             }

--- a/RavenMigrations.Tests/RunnerTests.cs
+++ b/RavenMigrations.Tests/RunnerTests.cs
@@ -18,7 +18,7 @@ namespace RavenMigrations.Tests
         [Fact]
         public void Can_change_migration_document_seperator_to_dash()
         {
-            new First_Migration().GetMigrationIdFromName(seperator: '-')
+            RavenMigrationHelpers.GetMigrationIdFromName(new First_Migration(), seperator: '-')
                 .Should().Be("ravenmigrations-first-migration-1");
         }
 
@@ -31,7 +31,7 @@ namespace RavenMigrations.Tests
         [Fact]
         public void Can_get_migration_id_from_migration()
         {
-            var id = new First_Migration().GetMigrationIdFromName();
+            var id = RavenMigrationHelpers.GetMigrationIdFromName(new First_Migration());
             id.Should().Be("ravenmigrations/first/migration/1");
         }
 
@@ -101,6 +101,33 @@ namespace RavenMigrations.Tests
                     session.Query<TestDocument, TestDocumentIndex>()
                         .Count()
                         .Should().Be(1);
+                }
+            }
+        }
+        
+        [Fact]
+        public void Can_run_a_migration_using_an_alternative_migration_to_document_id_conversion()
+        {
+            int idx = 1;
+            var optionsWithConverter = new MigrationOptions
+            {
+                ConvertToDocumentId = (m, s) =>
+                    RavenMigrationHelpers.RavenMigrationsIdPrefix + s + "test.a.b.c." + (idx++)
+            };
+
+            using (var store = NewDocumentStore())
+            {
+                new TestDocumentIndex().Execute(store);
+
+                Runner.Run(store, optionsWithConverter);
+                WaitForIndexing(store);
+
+                using (var session = store.OpenSession())
+                {
+                    var migrationDocuments = session.Load<MigrationDocument>("ravenmigrations/test.a.b.c.1", "ravenmigrations/test.a.b.c.2");
+                    migrationDocuments
+                        .Count(d => d != null)
+                        .Should().Be(2);
                 }
             }
         }

--- a/RavenMigrations/MigrationOptions.cs
+++ b/RavenMigrations/MigrationOptions.cs
@@ -13,6 +13,7 @@ namespace RavenMigrations
             MigrationResolver = new DefaultMigrationResolver();
             Assemblies = new List<Assembly>();
             ToVersion = 0;
+            ConvertToDocumentId = RavenMigrationHelpers.GetMigrationIdFromName;
         }
 
         public Directions Direction { get; set; }
@@ -20,5 +21,6 @@ namespace RavenMigrations
         public IList<string> Profiles { get; set; }
         public IMigrationResolver MigrationResolver { get; set; }
         public long ToVersion { get; set; }
+        public MigrationToDocumentIdConversion ConvertToDocumentId { get; set; }
     }
 }

--- a/RavenMigrations/MigrationToDocumentIdConversion.cs
+++ b/RavenMigrations/MigrationToDocumentIdConversion.cs
@@ -1,0 +1,4 @@
+namespace RavenMigrations
+{
+    public delegate string MigrationToDocumentIdConversion(Migration migration, char defaultIdentityPartsSeparator);
+}

--- a/RavenMigrations/RavenMigrationHelpers.cs
+++ b/RavenMigrations/RavenMigrationHelpers.cs
@@ -11,7 +11,7 @@ namespace RavenMigrations
     {
         public static readonly string RavenMigrationsIdPrefix = "ravenmigrations";
 
-        public static string GetMigrationIdFromName(this Migration migration, char seperator = '/')
+        public static string GetMigrationIdFromName(Migration migration, char seperator = '/')
         {
             var type = migration.GetType();
             var name = type

--- a/RavenMigrations/RavenMigrations.csproj
+++ b/RavenMigrations/RavenMigrations.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Migration.cs" />
     <Compile Include="MigrationDocument.cs" />
     <Compile Include="MigrationOptions.cs" />
+    <Compile Include="MigrationToDocumentIdConversion.cs" />
     <Compile Include="MigrationWithAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RavenMigrationHelpers.cs" />

--- a/RavenMigrations/Runner.cs
+++ b/RavenMigrations/Runner.cs
@@ -25,8 +25,7 @@ namespace RavenMigrations
                 migration.Setup(documentStore);
 
                 // todo: possible issue here with sharding
-                var migrationId = 
-                    migration.GetMigrationIdFromName(documentStore.Conventions.IdentityPartsSeparator[0]);
+                var migrationId = options.ConvertToDocumentId(migration, documentStore.Conventions.IdentityPartsSeparator[0]);
 
                 using (var session = documentStore.OpenSession())
                 {


### PR DESCRIPTION
The alternative conversion is set in MigrationOptions, if required.

Existing GetMIgrationIdFromName method (still the default conversion) is no longer an extension of Migration - this is now assigned as the conversion delegate in Migration Options
