### PR TITLE
Throw when migrations are missing attribute.

### DIFF
--- a/RavenMigrations.Tests/RunnerTests.cs
+++ b/RavenMigrations.Tests/RunnerTests.cs
@@ -344,7 +344,7 @@ namespace RavenMigrations.Tests
         }
     }    
 
-    public class BaseMigration : Migration
+    public abstract class BaseMigration : Migration
     {
         public override void Up()
         {


### PR DESCRIPTION
Throw an exception when migrations are missing the MigrationAttribute.
If the class does not have a parameterless constructor or it is
abstract, exclude it from the migrations altogether. Addresses #31.