### PR TITLE
Allow migrations to produce additional commands

### DIFF
--- a/RavenMigrations/RavenMigrationHelpers.cs
+++ b/RavenMigrations/RavenMigrationHelpers.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RavenMigrations
 {

--- a/RavenMigrations/Runner.cs
+++ b/RavenMigrations/Runner.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Raven.Client;
-using Raven.Client.Indexes;
 
 namespace RavenMigrations
 {

--- a/RavenMigrations/Verbs/Alter.cs
+++ b/RavenMigrations/Verbs/Alter.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Raven.Abstractions.Commands;
 using Raven.Abstractions.Data;
+using Raven.Abstractions.Extensions;
 using Raven.Client;
 using Raven.Json.Linq;
 
@@ -20,7 +22,7 @@ namespace RavenMigrations.Verbs
         /// <param name="tag">The name of the collection.</param>
         /// <param name="action">The action to migrate a single document and metadata.</param>
         /// <param name="pageSize">The page size for batching the documents.</param>
-        public void Collection(string tag, Action<RavenJObject, RavenJObject> action, int pageSize = 128)
+        public void Collection(string tag, Func<RavenJObject, RavenJObject, IEnumerable<ICommandData>> action, int pageSize = 128)
         {
             QueryHeaderInformation headerInfo;
             var enumerator = DocumentStore.DatabaseCommands.StreamQuery("Raven/DocumentsByEntityName",
@@ -31,33 +33,61 @@ namespace RavenMigrations.Verbs
                 out headerInfo);
 
 
-            var cmds = new List<ICommandData>();
+            var actions = new RavenActions();
             using (enumerator)
             while (enumerator.MoveNext())
             {
                 var entity = enumerator.Current;
                 var metadata = entity.Value<RavenJObject>("@metadata");
 
-                action(entity, metadata);
+                var actionCommands = action(entity, metadata);
 
-                cmds.Add(new PutCommandData
+                if (actionCommands != null && actionCommands.ToList().Any())
+                {
+                    actions.AdditionalMigrationCommands.AddRange(actionCommands);
+                }
+
+                actions.MigrationCommands.Add(new PutCommandData
                 {
                     Document = entity,
                     Metadata = metadata,
                     Key = metadata.Value<string>("@id"),
                 });
 
-                if (cmds.Count == pageSize)
+                if (actions.MigrationCommands.Count == pageSize)
                 {
-                    DocumentStore.DatabaseCommands.Batch(cmds.ToArray());
-                    cmds.Clear();
+                    DocumentStore.DatabaseCommands.Batch(actions.AllCommands());
+                    actions.ClearMigrationCommands();
                 }
             }
 
-            if (cmds.Count > 0)
-                DocumentStore.DatabaseCommands.Batch(cmds.ToArray());
+            if (actions.AllCommands().Count > 0)
+                DocumentStore.DatabaseCommands.Batch(actions.AllCommands());
         }
 
         protected IDocumentStore DocumentStore { get; private set; }
+    }
+
+    public class RavenActions
+    {
+        public IList<ICommandData> MigrationCommands { get; set; }
+        public IList<ICommandData> AdditionalMigrationCommands { get; set; }
+
+        public RavenActions()
+        {
+            MigrationCommands = new List<ICommandData>();
+            AdditionalMigrationCommands = new List<ICommandData>();
+        }
+
+        public IList<ICommandData> AllCommands()
+        {
+            return MigrationCommands.Union(AdditionalMigrationCommands).ToList();
+        }
+
+        public void ClearMigrationCommands()
+        {
+            MigrationCommands.Clear();
+            AdditionalMigrationCommands.Clear();
+        }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,23 @@ You now need to migrating your documents or you will lose data when you load you
     }
 ```
 
+#### Alter.CollectionWithAdditionalCommands
+```Alter.CollectionWithAdditionalCommands``` works just like ```Alter.Collection``` except the function you pass to it
+must return an ```IEnumerable<ICommandData>```. These are additional RavenDb commands that will be applied in the same transaction
+as the document of the collection you are modifying. So, if anything goes wrong, you can be sure that no documents of the
+collection were changed without also doing the corresponding "additional" changes. An example scenario: you want to migrate a field
+from one document to a different document. There are two things that need to happen: 1. remove the old field, 2. set the new field
+on the other document. With this helper method, you can batch both of those commands in the same transaction, so they'll both either
+pass or fail together. An example of an additional command:
+
+```
+new PutCommand {
+    Document = new RavenJObject(),
+    Key = "foobar/1",
+    Metadata = new RavenJObject()
+}
+```
+
 #### Working with Metadata
 Let's say that you refactor and move ```Person``` to another assembly.  So that RavenDB will load the data into the new class, you will need to adjust the metadata in the collection for the new CLR type.
 


### PR DESCRIPTION
Alter.Collection can be used now to add additional ICommandData to the
Alter.Collection batch. This makes it so you can safely add new
documents or make changes to additional documents and have it be part of
the same batch / transaction.

This is a slight refactor of #28. This version maintains backwards compatibility
by using a new method ```CollectionWithAdditionalCommands``` for the new behavior.
Collection will still behave the same as before.