### PR TITLE
Added ability to pass a custom logger into migrations via the runner.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes will be documented in this file, particularly any breaking
 changes. This project adheres to [Semantic Versioning](http://semver.org).
 
 ## [x.x.x]
+- Added `Action<string> Log { get; set; }` property to `MigrationOptions` to allow 
+  a custom logger to be passed into migrations.  Also added 
+  `protected void Log(string message);` to abstract `Migration` class which calls
+  the custom logger if one has been specified and `Debug.WriteLine` otherwise.
 
 ## [2.0.0]
 - Changed (breaking) - The way the MigrationDocument's Id is determined. Multiple underscores

--- a/RavenMigrations.Tests/RunnerTests.cs
+++ b/RavenMigrations.Tests/RunnerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using Raven.Abstractions.Data;
 using Raven.Client.Indexes;
@@ -284,6 +285,21 @@ namespace RavenMigrations.Tests
                 }
             }
         }
+
+        [Fact]
+        public void Migrations_log()
+        {
+            var logHistory = new List<string>();
+
+            using (var store = NewDocumentStore())
+            {
+                Runner.Run(store, new MigrationOptions { Profiles = new[] { "logs" }, Logger = s => logHistory.Add(s)});
+            }
+
+            logHistory.Count.Should().Be(2);
+            logHistory[0].Should().Be("Test log message 1");
+            logHistory[1].Should().Be("Test log message 2");
+        }
     }
 
     public class TestDocument
@@ -375,7 +391,17 @@ namespace RavenMigrations.Tests
         public override void Up()
         {
         }
-    }    
+    }
+
+    [Migration(5, "logs")]
+    public class Logs : Migration
+    {
+        public override void Up()
+        {
+            Log("Test log message 1");
+            Log("Test log message 2");
+        }
+    }
 
     [MigrationVersion(6, 0, 0, 0)]
     public class Uses_Custom_Migration_Attribute : Migration

--- a/RavenMigrations/Migration.cs
+++ b/RavenMigrations/Migration.cs
@@ -1,4 +1,6 @@
-﻿using Raven.Client;
+﻿using System;
+using System.Diagnostics;
+using Raven.Client;
 using RavenMigrations.Extensions;
 using RavenMigrations.Verbs;
 
@@ -10,10 +12,11 @@ namespace RavenMigrations
         {
         }
 
-        public virtual void Setup(IDocumentStore documentStore)
+        public virtual void Setup(IDocumentStore documentStore, Action<string> logger = null)
         {
             DocumentStore = documentStore;
             Alter = new Alter(documentStore);
+            _logger = logger;
         }
 
         public abstract void Up();
@@ -23,7 +26,16 @@ namespace RavenMigrations
             DocumentStore.WaitForIndexing();
         }
 
+        protected void Log(string message)
+        {
+            if (_logger != null)
+                _logger(message);
+            else
+                Debug.WriteLine(message);
+        }
         protected Alter Alter { get; private set; }
         protected IDocumentStore DocumentStore { get; private set; }
+
+        private Action<string> _logger;
     }
 }

--- a/RavenMigrations/MigrationOptions.cs
+++ b/RavenMigrations/MigrationOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace RavenMigrations
@@ -20,5 +21,6 @@ namespace RavenMigrations
         public IList<string> Profiles { get; set; }
         public IMigrationResolver MigrationResolver { get; set; }
         public long ToVersion { get; set; }
+        public Action<string> Logger { get; set; }
     }
 }

--- a/RavenMigrations/Runner.cs
+++ b/RavenMigrations/Runner.cs
@@ -22,7 +22,7 @@ namespace RavenMigrations
             {
                 // send in the document Store
                 var migration = pair.Migration();
-                migration.Setup(documentStore);
+                migration.Setup(documentStore, options.Logger);
 
                 // todo: possible issue here with sharding
                 var migrationId = 


### PR DESCRIPTION
Added `Action<string> Log { get; set; }` property to `MigrationOptions` to allow  a custom logger to be passed into migrations.  

Also added  `protected void Log(string message);` to abstract `Migration` class which calls the custom logger if one has been specified and `Debug.WriteLine` otherwise.