### PR TITLE
Add more extension points for customization

### DIFF
--- a/Raven.Migrations.Tests/AlterTests.cs
+++ b/Raven.Migrations.Tests/AlterTests.cs
@@ -25,7 +25,7 @@ namespace Raven.Migrations.Tests
                 var professorZoom = InitialiseWithPerson(store, "Professor", "Zoom");
 
                 var migration = new AddFullName();
-                migration.Setup(store, logger);
+                migration.Setup(store, new MigrationOptions(), logger);
 
                 migration.Up();
 
@@ -45,7 +45,7 @@ namespace Raven.Migrations.Tests
                 var ladyDeathstrike = InitialiseWithPerson(store, "Lady", "Deathstrike");
 
                 var migration = new AddFullName();
-                migration.Setup(store, logger);
+                migration.Setup(store, new MigrationOptions(), logger);
 
                 migration.Up();
                 WaitForIndexing(store);
@@ -71,7 +71,7 @@ namespace Raven.Migrations.Tests
                 var scarletSpider = InitialiseWithPerson(store, "Scarlet", "Spider");
 
                 var migration = new AddFullName();
-                migration.Setup(store, loggerMock.Object);
+                migration.Setup(store, new MigrationOptions(), loggerMock.Object);
 
                 migration.Up();
             }
@@ -95,7 +95,7 @@ namespace Raven.Migrations.Tests
                     new Person {FirstName = "Killer", LastName = "Croc" }
                 });
                 var migration = new AddFullName();
-                migration.Setup(store, loggerMock.Object);
+                migration.Setup(store, new MigrationOptions(), loggerMock.Object);
 
                 migration.Up();
             }

--- a/Raven.Migrations.Tests/RunnerTests.cs
+++ b/Raven.Migrations.Tests/RunnerTests.cs
@@ -18,21 +18,24 @@ namespace Raven.Migrations.Tests
         [Fact]
         public void Can_change_migration_document_seperator_to_dash()
         {
-            new First_Migration().GetMigrationIdFromName(seperator: '-')
+            var options = new MigrationOptions();
+            options.Conventions.MigrationDocumentId(new First_Migration(), '-')
                 .Should().Be("migrationrecord-first-migration-1");
         }
 
         [Fact]
         public void Can_get_migration_id_from_migration()
         {
-            var id = new First_Migration().GetMigrationIdFromName();
+            var options = new MigrationOptions();
+            var id = options.Conventions.MigrationDocumentId(new First_Migration(), '/');
             id.Should().Be("migrationrecord/first/migration/1");
         }
 
         [Fact]
         public void Can_get_migration_id_from_migration_and_correct_leading_or_multiple_underscores()
         {
-            var id = new _has_problems__with_underscores___().GetMigrationIdFromName();
+            var options = new MigrationOptions();
+            var id = options.Conventions.MigrationDocumentId(new _has_problems__with_underscores___(), '/');
             id.Should().Be("migrationrecord/has/problems/with/underscores/5");
         }
 
@@ -187,12 +190,12 @@ namespace Raven.Migrations.Tests
                         .Count()
                         .Should().Be(1);
 
-                    var secondMigrationDocument =
-                        session.Load<MigrationRecord>(new Second_Migration().GetMigrationIdFromName());
+                    var secondId = options.Conventions.MigrationDocumentId(new Second_Migration(), '/');
+                    var secondMigrationDocument = session.Load<MigrationRecord>(secondId);
                     secondMigrationDocument.Should().BeNull();
 
-                    var firstMigrationDocument =
-                        session.Load<MigrationRecord>(new First_Migration().GetMigrationIdFromName());
+                    var id = options.Conventions.MigrationDocumentId(new First_Migration(), '/');
+                    var firstMigrationDocument = session.Load<MigrationRecord>(id);
                     firstMigrationDocument.Should().NotBeNull();
                 }
             }

--- a/Raven.Migrations/DefaultMigrationRecordLoader.cs
+++ b/Raven.Migrations/DefaultMigrationRecordLoader.cs
@@ -1,0 +1,47 @@
+﻿using Raven.Client.Documents;
+
+namespace Raven.Migrations
+{
+    public class DefaultMigrationRecordStore : IMigrationRecordStore
+    {
+        private readonly IDocumentStore store;
+        private readonly MigrationOptions options;
+
+        public DefaultMigrationRecordStore(
+            IDocumentStore store,
+            MigrationOptions options)
+        {
+            this.store = store;
+            this.options = options;
+        }
+
+        public IMigrationRecord Load(string migrationId)
+        {
+            using (var session = store.OpenSession(options.Database))
+            {
+                return session.Load<MigrationRecord>(migrationId);
+            }
+        }
+
+        public void Delete(IMigrationRecord record)
+        {
+            using (var session = store.OpenSession(options.Database))
+            {
+                session.Delete(record.Id);
+                session.SaveChanges();
+            }
+        }
+
+        public void Store(string migrationId)
+        {
+            using (var session = store.OpenSession(options.Database))
+            {
+                session.Store(new MigrationRecord
+                {
+                    Id = migrationId
+                });
+                session.SaveChanges();
+            }
+        }
+    }
+}

--- a/Raven.Migrations/IMigrationRecord.cs
+++ b/Raven.Migrations/IMigrationRecord.cs
@@ -1,0 +1,7 @@
+﻿namespace Raven.Migrations
+{
+    public interface IMigrationRecord
+    {
+        string Id { get; }
+    }
+}

--- a/Raven.Migrations/IMigrationRecordLoader.cs
+++ b/Raven.Migrations/IMigrationRecordLoader.cs
@@ -1,0 +1,9 @@
+﻿namespace Raven.Migrations
+{
+    public interface IMigrationRecordStore
+    {
+        IMigrationRecord Load(string migrationId);
+        void Store(string migrationId);
+        void Delete(IMigrationRecord record);
+    }
+}

--- a/Raven.Migrations/MigrationAttribute.cs
+++ b/Raven.Migrations/MigrationAttribute.cs
@@ -21,5 +21,6 @@ namespace Raven.Migrations
 
         public long Version { get; set; }
         public IEnumerable<string> Profiles { get; set; }
+        public string Description { get; set; }
     }
 }

--- a/Raven.Migrations/MigrationConventions.cs
+++ b/Raven.Migrations/MigrationConventions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Raven.Migrations
+{
+    public class MigrationConventions
+    {
+        public MigrationConventions()
+        {
+            TypeIsMigration = RavenMigrationHelpers.TypeIsMigration;
+            MigrationDocumentId = RavenMigrationHelpers.GetMigrationDocumentId;
+        }
+
+        public Func<Type, bool> TypeIsMigration { get; set; }
+        public Func<Migration, char, string> MigrationDocumentId { get; set; }
+    }
+}

--- a/Raven.Migrations/MigrationOptions.cs
+++ b/Raven.Migrations/MigrationOptions.cs
@@ -13,12 +13,16 @@ namespace Raven.Migrations
             MigrationResolver = new DefaultMigrationResolver();
             Assemblies = new List<Assembly>();
             ToVersion = 0;
+            Conventions = new MigrationConventions();
         }
 
+        public string Database { get; set; }
         public Directions Direction { get; set; }
         public IList<Assembly> Assemblies { get; set; }
         public IList<string> Profiles { get; set; }
         public IMigrationResolver MigrationResolver { get; set; }
         public int ToVersion { get; set; }
+        public MigrationConventions Conventions { get; set; }
+        public IMigrationRecordStore MigrationRecordStore { get; set; }
     }
 }

--- a/Raven.Migrations/MigrationRecord.cs
+++ b/Raven.Migrations/MigrationRecord.cs
@@ -2,7 +2,7 @@
 
 namespace Raven.Migrations
 {
-    public class MigrationRecord
+    public class MigrationRecord : IMigrationRecord
     {
         public string Id { get; set; }
         public DateTimeOffset RunOn { get; set; } = DateTimeOffset.UtcNow;

--- a/Raven.Migrations/RavenMigrationHelpers.cs
+++ b/Raven.Migrations/RavenMigrationHelpers.cs
@@ -10,27 +10,25 @@ namespace Raven.Migrations
     {
         public static readonly string RavenMigrationsIdPrefix = "MigrationRecord";
 
-        public static string GetMigrationIdFromName(this Migration migration, char seperator = '/')
+        public static string GetMigrationDocumentId(Migration migration, char separator)
         {
-            const char underscore = '_';
+            const char Underscore = '_';
             var type = migration.GetType();
-            var idSafeTypeName = Regex.Replace(type.Name, underscore + "{2,}", underscore.ToString())
-                .Trim(underscore);
+            var idSafeTypeName = Regex.Replace(type.Name, Underscore + "{2,}", Underscore.ToString())
+                .Trim(Underscore);
             var name = idSafeTypeName
-                .Replace(underscore, seperator)
+                .Replace(Underscore, separator)
                 .ToLowerInvariant();
             var version = type.GetMigrationAttribute().Version;
 
-            return string.Join(seperator.ToString(), new[] {
-                RavenMigrationsIdPrefix, name, version.ToString()
-            }).ToLowerInvariant();
+            return string.Join(separator.ToString(), RavenMigrationsIdPrefix, name, version.ToString()).ToLowerInvariant();
         }
 
         public static MigrationAttribute GetMigrationAttribute(this Type type)
         {
             var attribute = Attribute.GetCustomAttributes(type)
                 .FirstOrDefault(x => x is MigrationAttribute);
-            return (MigrationAttribute)attribute;
+            return (MigrationAttribute) attribute;
         }
 
         public static IEnumerable<Type> GetLoadableTypes(this Assembly assembly)
@@ -39,6 +37,7 @@ namespace Raven.Migrations
             {
                 throw new ArgumentNullException(nameof(assembly));
             }
+
             try
             {
                 return assembly.GetTypes();
@@ -48,5 +47,9 @@ namespace Raven.Migrations
                 return e.Types.Where(t => t != null);
             }
         }
+
+        public static readonly Func<Type, bool> TypeIsMigration = t => typeof(Migration).IsAssignableFrom(t)
+                                                                       && !t.IsAbstract
+                                                                       && t.GetConstructor(Type.EmptyTypes) != null;
     }
 }


### PR DESCRIPTION
This PR seems to address most of our migration from FluentMigrator based custom made migration framework. We can now use conventions to tell which document ids we are using and then handle storage of record of our own type. This also allows as to circument the current shortcoming that migration record is inserted in different UoW, we just use custom repository that never stores, it's our migration attributes Up logic that handles storage as part of the UoW.

This should be quite backwards compatible, adding more customization points and tweaking internal logic.

One important thing here is to allow customization of Database, now running against specific database supplied from outside is easy. This is why I also obsoleted Db as property for document store at it's confusing, DocumentStore + Database tell you the story.

Tests are green.