### PR TITLE
Include migration version and execution times in runner

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ install:
   - ps: $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
 
 build_script:
+  - dotnet restore
   - dotnet --version
   - dotnet pack -c Release
 


### PR DESCRIPTION
I included migration version number and execution times to runner output. It makes it easier to investigate runs against different databases and to determine possible bottlenecks. Migration numbers also clarify better than just migration names.