### PR TITLE
Trim dependencies and generate symbols

### DIFF
--- a/Raven.Migrations.Tests/Raven.Migrations.Tests.csproj
+++ b/Raven.Migrations.Tests/Raven.Migrations.Tests.csproj
@@ -10,8 +10,6 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
     <PackageReference Include="RavenDB.TestDriver" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/Raven.Migrations/Raven.Migrations.csproj
+++ b/Raven.Migrations/Raven.Migrations.csproj
@@ -26,13 +26,15 @@
     <RepositoryUrl>https://github.com/migrating-ravens/RavenMigrations/</RepositoryUrl>
 
     <nullable>enable</nullable>
+
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.6" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="RavenDB.Client" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
I did a quick check as I'm starting my own fork to get netstandard2.0 compatibility and found couple issues that you might want to check out.

* Remove unnecessary dependencies from main library and depend on abstractions
* Mark SourceLink as private asset as it's only used in build and should not create a public dependency
* Also generate symbols that can be uploaded to NuGet to improve debugging experience
* Remove MSTest leftovers from testing project
