### PR TITLE
Support different behaviors for migration lock obtain error

### DIFF
--- a/Raven.Migrations/MigrationOptions.cs
+++ b/Raven.Migrations/MigrationOptions.cs
@@ -46,5 +46,26 @@ namespace Raven.Migrations
         /// If <see cref="PreventSimultaneousMigrations"/> is enabled, any attempt to run migrations during this time will fail.
         /// </summary>
         public TimeSpan SimultaneousMigrationTimeout { get; set; }
+
+        /// <summary>
+        /// What to do when migration lock cannot be obtained. Default behavior is to skip running migrations.
+        /// </summary>
+        public SimultaneousMigrationBehavior SimultaneousMigrationBehavior { get; set; } = SimultaneousMigrationBehavior.Skip;
+    }
+
+    /// <summary>
+    /// Behavior options when attempt to run simultaneous migrations.
+    /// </summary>
+    public enum SimultaneousMigrationBehavior
+    {
+        /// <summary>
+        /// Skip migration and log warning-
+        /// </summary>
+        Skip,
+
+        /// <summary>
+        /// Throw an exception and effectively cancel the migration attempt.
+        /// </summary>
+        Error
     }
 }

--- a/Raven.Migrations/MigrationRunner.cs
+++ b/Raven.Migrations/MigrationRunner.cs
@@ -38,7 +38,14 @@ namespace Raven.Migrations
             }
             if (!canRunMigrations)
             {
-                logger.LogWarning("Skipping migrations because migrations are already running.");
+                if (options.SimultaneousMigrationBehavior == SimultaneousMigrationBehavior.Skip)
+                {
+                    logger.LogWarning("Skipping migrations because migrations are already running.");
+                }
+                else if (options.SimultaneousMigrationBehavior == SimultaneousMigrationBehavior.Error)
+                {
+                    throw new InvalidOperationException("Could not get exclusive lock to run migration");
+                }
             }
             else
             {


### PR DESCRIPTION
To my surprise, the library could just skip running migrations if there was a lingering lock from process crash or similar. Added an option to abort the whole process as this can be really hard to spot when handling large amount of databases. Default behavior is the old one where only warning is being logged.